### PR TITLE
[Download] Add --include-archives option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,20 @@ $ octoscan dl -h
 Octoscan.
 
 Usage:
-	octoscan dl [options] --org <org> [--repo <repo> --token <pat> --default-branch --max-branches <num> --path <path> --output-dir <dir>]
+	octoscan dl [options] --org <org> [--repo <repo> --token <pat> --default-branch --max-branches <num> --path <path> --output-dir <dir> --include-archives]
 
 Options:
 	-h, --help  						Show help
 	-d, --debug  						Debug output
 	--verbose  						Verbose output
-	--org <org> 						Organizations to target
-	--repo <repo>						Repository to target
-	--token <pat>						GHP to authenticate to GitHub
+	--org <org>  						Organizations to target
+	--repo <repo>  						Repository to target
+	--token <pat>  						GHP to authenticate to GitHub
 	--default-branch  					Only download workflows from the default branch
 	--max-branches <num>  					Limit the number of branches to download
-	--path <path>						GitHub file path to download [default: .github/workflows]
-	--output-dir <dir>					Output dir where to download files [default: octoscan-output]
+	--path <path>  						GitHub file path to download [default: .github/workflows]
+	--output-dir <dir>  					Output dir where to download files [default: octoscan-output]
+	--include-archives  					Also download archived repositories
 ```
 
 ```sh

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -17,13 +17,13 @@ Options:
 	-h, --help  						Show help
 	-d, --debug  						Debug output
 	--verbose  						Verbose output
-	--org <org> 						Organizations to target
-	--repo <repo>						Repository to target
-	--token <pat>						GHP to authenticate to GitHub
+	--org <org>  						Organizations to target
+	--repo <repo>  						Repository to target
+	--token <pat>  						GHP to authenticate to GitHub
 	--default-branch  					Only download workflows from the default branch
 	--max-branches <num>  					Limit the number of branches to download
-	--path <path>						GitHub file path to download [default: .github/workflows]
-	--output-dir <dir>					Output dir where to download files [default: octoscan-output]
+	--path <path>  						GitHub file path to download [default: .github/workflows]
+	--output-dir <dir>  					Output dir where to download files [default: octoscan-output]
 
 `
 
@@ -38,14 +38,6 @@ func runDownloader(args docopt.Opts) error {
 	maxBranches, _ := args.Int("--max-branches")
 
 	path = strings.Trim(path, "/")
-	// docopt is not working with the default arg I don't know why !
-	if path == "" {
-		path = ".github/workflows"
-	}
-
-	if dir == "" {
-		dir = "octoscan-output"
-	}
 
 	ghOpts := core.GitHubOptions{
 		Path:              path,

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -11,7 +11,7 @@ import (
 var usageDownload = `Octoscan.
 
 Usage:
-	octoscan dl [options] --org <org> [--repo <repo> --token <pat> --default-branch --max-branches <num> --path <path> --output-dir <dir>]
+	octoscan dl [options] --org <org> [--repo <repo> --token <pat> --default-branch --max-branches <num> --path <path> --output-dir <dir> --include-archives]
 
 Options:
 	-h, --help  						Show help
@@ -24,6 +24,7 @@ Options:
 	--max-branches <num>  					Limit the number of branches to download
 	--path <path>  						GitHub file path to download [default: .github/workflows]
 	--output-dir <dir>  					Output dir where to download files [default: octoscan-output]
+	--include-archives  					Also download archived repositories
 
 `
 
@@ -46,6 +47,7 @@ func runDownloader(args docopt.Opts) error {
 		Token:             token,
 		DefaultBranchOnly: args["--default-branch"].(bool),
 		MaxBranches:       maxBranches,
+		IncludeArchives:   args["--include-archives"].(bool),
 	}
 
 	gh := core.NewGitHub(ghOpts)

--- a/core/downloader.go
+++ b/core/downloader.go
@@ -22,6 +22,7 @@ type GitHub struct {
 	count             int
 	defaultBranchOnly bool
 	maxBranches       int
+	includeArchives   bool
 }
 
 type GitHubOptions struct {
@@ -32,6 +33,7 @@ type GitHubOptions struct {
 	OutputDir         string
 	DefaultBranchOnly bool
 	MaxBranches       int
+	IncludeArchives   bool
 }
 
 func NewGitHub(opts GitHubOptions) *GitHub {
@@ -150,8 +152,6 @@ func (gh *GitHub) getUserRepos() ([]*github.Repository, error) {
 }
 
 func (gh *GitHub) DownloadRepo(repo string) error {
-	common.Log.Info(fmt.Sprintf("Downloading files of repo: %s", repo))
-
 	// check rate limit
 	err := gh.checkRateLimit()
 	if err != nil {
@@ -169,6 +169,14 @@ func (gh *GitHub) DownloadRepo(repo string) error {
 
 		return err
 	}
+
+	if !gh.includeArchives && *repository.Archived {
+		common.Log.Debug(fmt.Sprintf("Not including %s because it has been archived", repo))
+
+		return nil
+	}
+
+	common.Log.Info(fmt.Sprintf("Downloading files of repo: %s", repo))
 
 	allBranches = append(allBranches, *repository.DefaultBranch)
 


### PR DESCRIPTION
This PR adds an `--include-archives` option that changes the download behavior.  Now, archived repositories won't be downloaded by default if this new option isn't specified. 
IMO, it makes more sense to exclude archived repositories by default since they're read only and thus can't be exploited. But if you feel that we should do the contrary, I can replace this option by `--exclude-archives` so archived remain downloaded by default, if the option is not specified.

This PR also fixes the issue related to default value not being processed by docopt. It seems that docopt does not like indentation using spaces and tabs. From the tests I did, the default value is parsed if the field is followed by 2 spaces.