### PR TITLE
Add OpenSSF Scoreboard analysis

### DIFF
--- a/.github/workflows/scoreboard.yml
+++ b/.github/workflows/scoreboard.yml
@@ -1,0 +1,35 @@
+name: Scorecard supply-chain security
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '16 0 * * 6'
+  push:
+    branches: [ "master" ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,19 +1,12 @@
 <div align="center">
 	:octocat:
+	<h1>octoscan</h1>
+	<p>Octoscan is a static vulnerability scanner for GitHub action workflows.</p>
+	<br>
+	<img src="img/dependabot.png"/>
+	<br>
+	<a href="https://securityscorecards.dev/viewer/?uri=github.com/synacktiv/octoscan"><img src="https://img.shields.io/ossf-scorecard/github.com/synacktiv/octoscan?label=openssf%20scorecard&style=for-the-badge" alt="OpenSSF Scoreboard"></a>
 </div>
-<h1 align="center">
-  octoscan
-</h1>
-
-<p align="center">
-   Octoscan is a static vulnerability scanner for GitHub action workflows.
-</p>
-
-<div align="center">
-  <img src="img/dependabot.png"/>
-</div>
-
-<br />
 
 ## Table of Contents
 


### PR DESCRIPTION
Currently, octoscan provides great audit value, but has no audit itself.

This PR brings the [OpenSSF Scoreboard](https://openssf.org/projects/scorecard/) as a continuous security audit tool. It should help contributors that are non-developers but have a security profile to give them guidelines on how to help octoscan improve its security practices and posture.

My last manually-triggered audit showed current CTFd scores 4.1/10 which highlights plenty room for improvement, but no big security defect. The expected behavior with Scoreboard is to raise both the score thus the security practices and the security knowledge of the community.
Moreover it has a cool badge 😄

Dependencies are [pinned as a good practice from OpenSSF](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies).
